### PR TITLE
include only pertinent files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "map",
     "ttl"
   ],
+  "files": [
+      "LICENSE",
+      "index.js"
+  ],
   "repository": "broadly/caching-map"
 }


### PR DESCRIPTION
ignores test files, .eslintrc, etc
